### PR TITLE
Update webpack to prevent Invalid Host/Origin header

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "style-loader": "^0.23.1",
     "webpack": "^4.26.1",
     "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.11"
+    "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {
     "react": "16.2",


### PR DESCRIPTION
Using webpack 3.1.1 we do have a annoying warning spam in console spaming in every 2 seconds, Invalid Host/Origin header, this solves the problem.